### PR TITLE
Fix model load path

### DIFF
--- a/lib/nsfw/model.rb
+++ b/lib/nsfw/model.rb
@@ -2,7 +2,8 @@ require "onnxruntime"
 
 module NSFW
   class Model
-    MODEL_PATH       = "vendor/onnx_models/nsfw.onnx"
+    ROOT_PATH        = Pathname.new(__dir__).parent.parent
+    MODEL_PATH       = "#{ROOT_PATH}/vendor/onnx_models/nsfw.onnx"
     CATEGORIES       = ['drawings', 'hentai', 'neutral', 'porn', 'sexy']
     SAFETY_THRESHOLD = 0.85
 


### PR DESCRIPTION
Hi.
Thanks you for create this gem.

I tried this gem, but couldn't load nsfw model.

```bash
/home/sh/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/onnxruntime-0.7.6-x86_64-linux/lib/onnxruntime/inference_session.rb:444:in `check_status': Load model from vendor/onnx_models/nsfw.onnx failed:Load model vendor/onnx_models/nsfw.onnx failed. File doesn't exist (OnnxRuntime::Error)
        from /home/sh/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/onnxruntime-0.7.6-x86_64-linux/lib/onnxruntime/inference_session.rb:195:in `load_session'
        from /home/sh/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/onnxruntime-0.7.6-x86_64-linux/lib/onnxruntime/inference_session.rb:58:in `initialize'
        from /home/sh/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/onnxruntime-0.7.6-x86_64-linux/lib/onnxruntime/model.rb:4:in `new'
        from /home/sh/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/onnxruntime-0.7.6-x86_64-linux/lib/onnxruntime/model.rb:4:in `initialize'
        from /home/sh/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/nsfw-rb-0.1.0/lib/nsfw/model.rb:36:in `new'
        from /home/sh/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/nsfw-rb-0.1.0/lib/nsfw/model.rb:36:in `load_model!'
        from /home/sh/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/nsfw-rb-0.1.0/lib/nsfw/model.rb:40:in `make_prediction'
        from /home/sh/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/nsfw-rb-0.1.0/lib/nsfw/model.rb:16:in `predict'
        from /home/sh/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/nsfw-rb-0.1.0/lib/nsfw/model.rb:21:in `safe?'
        from /home/sh/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/nsfw-rb-0.1.0/lib/nsfw/image.rb:50:in `safe?'
        from main.rb:3:in `<main>'
```

Thi pull request is fix to load nsfw model path error.